### PR TITLE
Fixed the functionality to get customers who have not placed an order

### DIFF
--- a/models/Customers.js
+++ b/models/Customers.js
@@ -79,7 +79,7 @@ const deleteSingleCustomer = (id) => {
 
 const getInactiveCustomers = () => {
   return new Promise( (resolve, reject) => {
-    db.all(`SELECT * FROM Customers WHERE active IS null`, (err, data) => {
+    db.all(`SELECT * FROM Customers LEFT OUTER JOIN Orders ON Customers.CustomerID = Orders.customer_id WHERE Orders.customer_id IS NULL`, (err, data) => {
       if (err) return reject(err);
       resolve(data);
     });


### PR DESCRIPTION
Initially this function selected users who had null for the active column in the Customers table.

Now this function selects users whose customer ID does not appear in the Orders table.

Test this using the following URL: http://localhost:3000/bangazon-api/customers/?active=false